### PR TITLE
Add check whether videos exist and display message when not. Closes #27

### DIFF
--- a/meetingsvideos/views.py
+++ b/meetingsvideos/views.py
@@ -190,7 +190,10 @@ class MeetingDetail(HTMXMixin, DetailView):
             parsed_param = [int(p) for p in param.split("-")]
             query_date = datetime.date(*parsed_param)
         else:
-            query_date = dates[0]
+            try:
+                query_date = dates[0]
+            except IndexError:
+                query_date = None
         context["videos"] = self.get_object().video_set.filter(date=query_date)
         return context
 

--- a/templates/meetingsvideos/meeting_detail.html
+++ b/templates/meetingsvideos/meeting_detail.html
@@ -3,6 +3,7 @@
 {% block main %}
 <div class="container" id="video-container">
   <h1>{{ meeting.display_date }}</h1>
+  {% if videos|length > 0 %}
   <ul class="nav nav-tabs" hx-target
   hx-on:htmx-after-on-load="let currentTab = document.querySelector('[aria-selected=true]');
                             console.log(currentTab)
@@ -28,5 +29,9 @@
   <div class="meetings-videos">
   {% include "meetingsvideos/meeting-video-list.html" %}
   </div>
+{% else %}
+<p>No videos are available for this meeting.</p>
+<p>{{ meeting.display_notes }}</p>
+{% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Adds a check in the view whether video dates exist. If not, returns None. Display notes for meeting are then displayed for the missing meeting.