### PR TITLE
Make loc-authorities a normal dependency. Closes #40

### DIFF
--- a/lcshfromvideos.py
+++ b/lcshfromvideos.py
@@ -1,5 +1,5 @@
 import csv, time, re
-from locpy.api import LocAPI, NameEntity, SubjectEntity, LocEntity
+from loc_authorities.api import LocAPI, NameEntity, SubjectEntity, LocEntity
 from wakepy import keep
 
 """

--- a/meetingsvideos/models.py
+++ b/meetingsvideos/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.db.models.functions import Substr
 from autoslug import AutoSlugField
 
-from locpy.api import LocEntity, NameEntity, SubjectEntity
+from loc_authorities.api import LocEntity, NameEntity, SubjectEntity
 import logging
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,17 @@ certifi==2025.8.3
 charset-normalizer==3.4.2
 diff-match-patch==20230430
 Django==5.2.3
+django-autoslug==1.9.9
 django-debug-toolbar==4.4.6
+django-htmx==1.23.2
 django-import-export==4.1.1
+gunicorn==23.0.0
 idna==3.10
-locpy @ git+https://github.com/AmericanPhilosophicalSociety/locpy@58cc2951bd15c97f9cf741d42b100a1103f4b5c5
+loc-authorities==0.2.0
+packaging==25.0
 pip-autoremove==0.10.0
 psycopg==3.2.2
+psycopg2-binary==2.9.10
 pyparsing==3.2.3
 python-dotenv==1.0.1
 rdflib==7.1.4
@@ -20,4 +25,3 @@ tablib==3.5.0
 typing_extensions==4.12.2
 tzdata==2024.1
 urllib3==2.5.0
-wakepy==0.10.2.post1


### PR DESCRIPTION
This PR changes the dependency from the alpha version of locpy to the published version of loc-authorities.

I flushed the database and reran everything and it seems to be working as expected.

Note that the requirements.txt file may have gotten polluted a bit with some requirements from the deploy branch. This shouldn't affect functionality, but it is not best practice.