### PR TITLE
Add nodes for 2010s-present program

### DIFF
--- a/meetings.csv
+++ b/meetings.csv
@@ -1,101 +1,101 @@
-display_date,start_date,end_date,display_notes,admin_notes,url,youtube_playlist,diglib_collection_node,program_node
-April 1976,,,,,,,528484,528485
-November 1976,,,,,,,,
-April 1977,,,,,,,,
-November 1977,,,,,,,528486,528487
-April 1978,,,,,,,,
-November 1978,,,,,,,528488,528489
-April 1979,,,,,,,,
-November 1979,,,,,,,528490,528491
-April 1980,,,,,,,,
-November 1980,,,,,,,,
-April 1981,,,,,,,528494,528495
-November 1981,,,,,,,528496,528497
-April 1982,,,,,,,528500,528501
-November 1982,,,,,,,528502,528503
-April 1983,,,,,,,528504,528505
-November 1983,,,,,,,528506,528507
-April 1984,,,,,,,528508,528509
-November 1984,,,,,,,528510,528511
-April 1985,,,,,,,528512,528513
-November 1985,,,,,,,528514,528515
-April 1986,,,,,,,528516,528517
-November 1986,,,,,,,528518,528519
-April 1987,,,,,,,528520,528521
-November 1987,,,,,,,528522,528523
-April 1988,,,,,,,528524,528525
-November 1988,,,,,,,528526,528527
-April 1989,,,,,,,528528,528529
-November 1989,,,,,,,528530,528531
-April 1990,,,,,,,528532,528533
-November 1990,,,,,,,528534,528535
-April 1991,,,,,,,528536,528537
-November 1991,,,,,,,528538,528539
-April 1992,,,,,,,528540,528541
-November 1992,,,,,,,528542,528543
-April 1993,,,,,,,528544,528545
-November 1993,,,,,,,528546,528547
-April 1994,,,,,,,528548,528549
-November 1994,,,,,,,528550,528551
-April 1995,,,,,,,528552,528553
-November 1995,,,,,,,528554,528555
-April 1996,,,,,,,528556,528557
-May 1996,,,,American Philosophical Society and Accademia nazionale dei Lincei joint meeting,,,528558,528559
-November 1996,,,,,,,528560,528561
-April 1997,,,,,,,528562,528563
-November 1997,,,,,,,528564,528565
-April 1998,,,,,,,528566,528567
-November 1998,,,,,,,528568,528569
-April 1999,,,,,,,528570,528571
-November 1999,,,,,,,528572,528573
-April 2000,,,,,,,528574,528575
-November 2000,,,,,,,528576,528577
-April 2001,,,,"Joint meeting between the American Philosophical Society, Royal Society, and British Academy",,,528578,528579
-November 2001,,,,,,,528580,528581
-April 2002,,,,,,,528582,528583
-November 2002,,,,,,,528584,528585
-April 2003,,,,,,,528586,528587
-November 2003,2003-11-14,2003-11-15,,,https://www.amphilsoc.org/members/meetings/november-2003,,316071,528588
-April 2004,2004-04-22,2004-04-24,,,https://www.amphilsoc.org/members/meetings/april-2004,,316066,528589
-November 2004,2004-11-11,2004-11-13,,,https://www.amphilsoc.org/members/meetings/november-2004,,316053,528590
-April 2005,2005-04-28,2005-04-30,,,https://www.amphilsoc.org/members/meetings/april-2005,,316070,528591
-November 2005,2005-11-10,2005-11-12,,,https://www.amphilsoc.org/members/meetings/november-2005,,316068,528592
-April 2006,2006-04-27,2006-04-29,,,https://www.amphilsoc.org/members/meetings/april-2006,,316051,528593
-November 2006,2006-11-09,2006-11-11,"The November 2006 meeting was held in San Francisco, CA.",Looks like this one wasn't recorded?,https://www.amphilsoc.org/members/meetings/november-2006,,,
-April 2007,2007-04-26,2007-04-28,,,https://www.amphilsoc.org/members/meetings/april-2007,,316047,528594
-November 2007,2007-11-08,2007-11-10,,,https://www.amphilsoc.org/members/meetings/november-2007,,316067,528595
-April 2008,2008-4-24,2008-4-26,,Missing from website,,,316073,528596
-November 2008,2008-11-13,2008-11-15,,,https://www.amphilsoc.org/members/meetings/november-2008,,316059,528597
-April 2009,2009-04-23,2009-04-25,,,https://www.amphilsoc.org/members/meetings/april-2009,,316060,528598
-November 2009,2009-11-12,2009-11-14,,,https://www.amphilsoc.org/members/meetings/november-2009,,316075,528599
-April 2010,2010-04-22,2010-04-24,,,https://www.amphilsoc.org/members/meetings/april-2010,,316077,
-November 2010,2010-11-11,2010-11-13,,,https://www.amphilsoc.org/members/meetings/november-2010,,316062,
-April 2011,2011-04-28,2011-04-30,,,https://www.amphilsoc.org/members/meetings/april-2011,,316061,
-November 2011,2011-11-17,2011-11-19,Dedicated to the Memory of Baruch S. Blumberg,,https://www.amphilsoc.org/members/meetings/november-2011,,316057,
-April 2012,2012-04-19,2012-04-21,"Talks on Friday, April 20 Offered in Celebration and Appreciation of Mary Patterson McPherson, Executive Officer (2007-2012)",,https://www.amphilsoc.org/members/meetings/april-2012,,316063,
-November 2012,2012-11-08,2012-11-10,,,https://www.amphilsoc.org/members/meetings/november-2012,,316069,
-April 2013,2013-04-25,2013-04-27,,,https://www.amphilsoc.org/members/meetings/april-2013,,316076,
-November 2013,2013-11-14,2013-11-16,,,https://www.amphilsoc.org/members/meetings/november-2013,,316072,
-April 2014,2014-04-24,2014-04-26,,,https://www.amphilsoc.org/members/meetings/april-2014,,316065,
-November 2014,2014-11-06,2014-11-08,,,https://www.amphilsoc.org/members/meetings/november-2014,,316064,
-April 2015,2015-04-23,2015-04-25,,Missing first day of talks,https://www.amphilsoc.org/members/meetings/april-2015,,316048,
-November 2015,2015-11-12,2015-11-14,,,https://www.amphilsoc.org/members/meetings/november-2015,,316058,
-April 2016,2016-04-28,2016-04-30,,Many missing videos,https://www.amphilsoc.org/members/meetings/april-2016,,316074,
-November 2016,2016-11-10,2016-11-12,,,https://www.amphilsoc.org/members/meetings/november-2016,https://www.youtube.com/watch?v=uTrLQOOv0O8&list=PLoKwLGnyZL4BuhuA-3NzBrlWc2wP8q0UG,316055,
-April 2017,2017-04-27,2017-04-29,,,https://www.amphilsoc.org/members/meetings/april-2017,,316056,
-November 2017,2017-11-09,2017-11-11,,,https://www.amphilsoc.org/members/meetings/november-2017,https://www.youtube.com/watch?v=svSk1njw0i0&list=PLoKwLGnyZL4BhNizacl3c7B8AoNTDT4WJ,316054,
-April 2018,2018-04-26,2018-04-28,,,https://www.amphilsoc.org/members/meetings/april-2018,,316049,
-November 2018,2018-11-08,2018-11-10,,,https://www.amphilsoc.org/members/meetings/november-2018,https://www.youtube.com/watch?v=WNYqEamqT4Q&list=PLoKwLGnyZL4DrbmF5SPmjYrZ5YyBVdYu0,316078,
-April 2019,2019-04-25,2019-04-27,,,https://www.amphilsoc.org/members/meetings/april-2019,https://www.youtube.com/watch?v=oTprxsO9w0I&list=PLoKwLGnyZL4BNQA-uZAiaTvzhfiD4Opo_,316050,
-November 2019,2019-11-07,2019-11-09,,,https://www.amphilsoc.org/members/meetings/november-2019,,316052,
-April 2020,2020-04-23,2020-04-25,The April 2020 Meeting of the American Philosophical Society was not held in person. This program as originally planned was canceled due to the COVID-19 pandemic. Members met via web conference only for essential committee and business planning.,,https://www.amphilsoc.org/members/meetings/april-2020,,,
-November 2020,2020-11-11,2020-11-13,The November 2020 Meeting of the American Philosophical Society was not held in person. All talks were held via Zoom webinar.,YouTube,https://www.amphilsoc.org/members/meetings/november-2020,https://www.youtube.com/watch?v=49ip-Xa0U58&list=PLoKwLGnyZL4ANb-6o2oasWjr_uDjXRkva,,
-April 2021,2021-04-21,2021-04-23,The April 2021 Meeting of the American Philosophical Society was not held in person. All talks were held via Zoom webinar.,,https://www.amphilsoc.org/members/meetings/april-2021,https://www.youtube.com/watch?v=WO8eNDLDDrQ&list=PLoKwLGnyZL4Cc8346Ix89c3oBjg--MwmD,,
-November 2021,2021-11-10,2021-11-12,The November 2021 Meeting of the American Philosophical Society was not be held in person. All talks were held via Zoom webinar.,,https://www.amphilsoc.org/members/meetings/november-2021,https://www.youtube.com/watch?v=Xq5Pe9f8o0k&list=PLoKwLGnyZL4AP36Mk9LtavWQQdyVfs9Q-,,
-April 2022,2022-04-27,2022-04-29,The April 2022 Meeting of the American Philosophical Society was not held in person. All talks were held via Zoom webinar.,,https://www.amphilsoc.org/members/meetings/april-2022,https://www.youtube.com/watch?v=izfAQ5UwGds&list=PLoKwLGnyZL4AETXKIpRUgrl9BMsgK84nV,,
-November 2022,2022-11-17,2022-11-19,,,https://www.amphilsoc.org/members/meetings/november-2022,https://www.youtube.com/watch?v=DTc4NrgUGG0&list=PLoKwLGnyZL4DmJDdA3-CRY76vPQK3YVos,,
-April 2023,2023-04-27,2023-04-29,,,https://www.amphilsoc.org/members/meetings/april-2023,https://www.youtube.com/watch?v=WrAabA9U6Ms&list=PLoKwLGnyZL4B9jyLDBLf5ObCiNKDuC4hg,,
-November 2023,2023-11-16,2023-11-18,,,https://www.amphilsoc.org/members/meetings/november-2023,https://www.youtube.com/watch?v=43HiO5DdoE4&list=PLoKwLGnyZL4CaJK873wLvAs_nxQZgNOwQ,,
-April 2024,2024-04-25,2024-04-27,,,https://www.amphilsoc.org/members/meetings/april-2024,https://www.youtube.com/watch?v=G9lhyqytTjU&list=PLoKwLGnyZL4Cd27HAgZKp1AMQ6uZAg_r4,,
-November 2024,2024-11-14,2024-11-16,,YouTube with good summaries,https://www.amphilsoc.org/members/meetings/november-2024,https://www.youtube.com/watch?v=Bw0EiZ3mR6k&list=PLoKwLGnyZL4BkEgjizLy3ocBdqwJBXOP4,,
-April 2025,2025-04-23,2025-04-25,,On YouTube but not linked on website program,https://www.amphilsoc.org/members/meetings/april-2025,https://www.youtube.com/watch?v=cSS66v_fVRE&list=PLoKwLGnyZL4DFRpB4l67tZ1AbGNDTldRY,,
+display_date,start_date,end_date,display_notes,admin_notes,url,youtube_playlist,diglib_collection_node,program_node,program_viewer
+April 1976,,,,,,,528484,528485,IIIF
+November 1976,,,,,,,,,
+April 1977,,,,,,,,,
+November 1977,,,,,,,528486,528487,IIIF
+April 1978,,,,,,,,,
+November 1978,,,,,,,528488,528489,IIIF
+April 1979,,,,,,,,,
+November 1979,,,,,,,528490,528491,IIIF
+April 1980,,,,,,,,,
+November 1980,,,,,,,,,
+April 1981,,,,,,,528494,528495,IIIF
+November 1981,,,,,,,528496,528497,IIIF
+April 1982,,,,,,,528500,528501,IIIF
+November 1982,,,,,,,528502,528503,IIIF
+April 1983,,,,,,,528504,528505,IIIF
+November 1983,,,,,,,528506,528507,IIIF
+April 1984,,,,,,,528508,528509,IIIF
+November 1984,,,,,,,528510,528511,IIIF
+April 1985,,,,,,,528512,528513,IIIF
+November 1985,,,,,,,528514,528515,IIIF
+April 1986,,,,,,,528516,528517,IIIF
+November 1986,,,,,,,528518,528519,IIIF
+April 1987,,,,,,,528520,528521,IIIF
+November 1987,,,,,,,528522,528523,IIIF
+April 1988,,,,,,,528524,528525,IIIF
+November 1988,,,,,,,528526,528527,IIIF
+April 1989,,,,,,,528528,528529,IIIF
+November 1989,,,,,,,528530,528531,IIIF
+April 1990,,,,,,,528532,528533,IIIF
+November 1990,,,,,,,528534,528535,IIIF
+April 1991,,,,,,,528536,528537,IIIF
+November 1991,,,,,,,528538,528539,IIIF
+April 1992,,,,,,,528540,528541,IIIF
+November 1992,,,,,,,528542,528543,IIIF
+April 1993,,,,,,,528544,528545,IIIF
+November 1993,,,,,,,528546,528547,IIIF
+April 1994,,,,,,,528548,528549,IIIF
+November 1994,,,,,,,528550,528551,IIIF
+April 1995,,,,,,,528552,528553,IIIF
+November 1995,,,,,,,528554,528555,IIIF
+April 1996,,,,,,,528556,528557,IIIF
+May 1996,,,,American Philosophical Society and Accademia nazionale dei Lincei joint meeting,,,528558,528559,IIIF
+November 1996,,,,,,,528560,528561,IIIF
+April 1997,,,,,,,528562,528563,IIIF
+November 1997,,,,,,,528564,528565,IIIF
+April 1998,,,,,,,528566,528567,IIIF
+November 1998,,,,,,,528568,528569,IIIF
+April 1999,,,,,,,528570,528571,IIIF
+November 1999,,,,,,,528572,528573,IIIF
+April 2000,,,,,,,528574,528575,IIIF
+November 2000,,,,,,,528576,528577,IIIF
+April 2001,,,,"Joint meeting between the American Philosophical Society, Royal Society, and British Academy",,,528578,528579,IIIF
+November 2001,,,,,,,528580,528581,IIIF
+April 2002,,,,,,,528582,528583,IIIF
+November 2002,,,,,,,528584,528585,IIIF
+April 2003,,,,,,,528586,528587,IIIF
+November 2003,2003-11-14,2003-11-15,,,https://www.amphilsoc.org/members/meetings/november-2003,,316071,528588,IIIF
+April 2004,2004-04-22,2004-04-24,,,https://www.amphilsoc.org/members/meetings/april-2004,,316066,528589,IIIF
+November 2004,2004-11-11,2004-11-13,,,https://www.amphilsoc.org/members/meetings/november-2004,,316053,528590,IIIF
+April 2005,2005-04-28,2005-04-30,,,https://www.amphilsoc.org/members/meetings/april-2005,,316070,528591,IIIF
+November 2005,2005-11-10,2005-11-12,,,https://www.amphilsoc.org/members/meetings/november-2005,,316068,528592,IIIF
+April 2006,2006-04-27,2006-04-29,,,https://www.amphilsoc.org/members/meetings/april-2006,,316051,528593,IIIF
+November 2006,2006-11-09,2006-11-11,"The November 2006 meeting was held in San Francisco, CA.",Looks like this one wasn't recorded?,https://www.amphilsoc.org/members/meetings/november-2006,,,,
+April 2007,2007-04-26,2007-04-28,,,https://www.amphilsoc.org/members/meetings/april-2007,,316047,528594,IIIF
+November 2007,2007-11-08,2007-11-10,,,https://www.amphilsoc.org/members/meetings/november-2007,,316067,528595,IIIF
+April 2008,2008-4-24,2008-4-26,,Missing from website,,,316073,528596,IIIF
+November 2008,2008-11-13,2008-11-15,,,https://www.amphilsoc.org/members/meetings/november-2008,,316059,528597,IIIF
+April 2009,2009-04-23,2009-04-25,,,https://www.amphilsoc.org/members/meetings/april-2009,,316060,528598,IIIF
+November 2009,2009-11-12,2009-11-14,,,https://www.amphilsoc.org/members/meetings/november-2009,,316075,528599,IIIF
+April 2010,2010-04-22,2010-04-24,,,https://www.amphilsoc.org/members/meetings/april-2010,,316077,,
+November 2010,2010-11-11,2010-11-13,,,https://www.amphilsoc.org/members/meetings/november-2010,,316062,,
+April 2011,2011-04-28,2011-04-30,,,https://www.amphilsoc.org/members/meetings/april-2011,,316061,535654,PDF
+November 2011,2011-11-17,2011-11-19,Dedicated to the Memory of Baruch S. Blumberg,,https://www.amphilsoc.org/members/meetings/november-2011,,316057,535656,PDF
+April 2012,2012-04-19,2012-04-21,"Talks on Friday, April 20 Offered in Celebration and Appreciation of Mary Patterson McPherson, Executive Officer (2007-2012)",,https://www.amphilsoc.org/members/meetings/april-2012,,316063,,
+November 2012,2012-11-08,2012-11-10,,,https://www.amphilsoc.org/members/meetings/november-2012,,316069,,
+April 2013,2013-04-25,2013-04-27,,,https://www.amphilsoc.org/members/meetings/april-2013,,316076,535657,PDF
+November 2013,2013-11-14,2013-11-16,,,https://www.amphilsoc.org/members/meetings/november-2013,,316072,535658,PDF
+April 2014,2014-04-24,2014-04-26,,,https://www.amphilsoc.org/members/meetings/april-2014,,316065,535659,PDF
+November 2014,2014-11-06,2014-11-08,,,https://www.amphilsoc.org/members/meetings/november-2014,,316064,535660,PDF
+April 2015,2015-04-23,2015-04-25,,Missing first day of talks,https://www.amphilsoc.org/members/meetings/april-2015,,316048,535661,PDF
+November 2015,2015-11-12,2015-11-14,,,https://www.amphilsoc.org/members/meetings/november-2015,,316058,535662,PDF
+April 2016,2016-04-28,2016-04-30,,Many missing videos,https://www.amphilsoc.org/members/meetings/april-2016,,316074,,
+November 2016,2016-11-10,2016-11-12,,,https://www.amphilsoc.org/members/meetings/november-2016,https://www.youtube.com/watch?v=uTrLQOOv0O8&list=PLoKwLGnyZL4BuhuA-3NzBrlWc2wP8q0UG,316055,535663,PDF
+April 2017,2017-04-27,2017-04-29,,,https://www.amphilsoc.org/members/meetings/april-2017,,316056,,
+November 2017,2017-11-09,2017-11-11,,,https://www.amphilsoc.org/members/meetings/november-2017,https://www.youtube.com/watch?v=svSk1njw0i0&list=PLoKwLGnyZL4BhNizacl3c7B8AoNTDT4WJ,316054,535664,PDF
+April 2018,2018-04-26,2018-04-28,,,https://www.amphilsoc.org/members/meetings/april-2018,,316049,535665,PDF
+November 2018,2018-11-08,2018-11-10,,,https://www.amphilsoc.org/members/meetings/november-2018,https://www.youtube.com/watch?v=WNYqEamqT4Q&list=PLoKwLGnyZL4DrbmF5SPmjYrZ5YyBVdYu0,316078,535666,PDF
+April 2019,2019-04-25,2019-04-27,,,https://www.amphilsoc.org/members/meetings/april-2019,https://www.youtube.com/watch?v=oTprxsO9w0I&list=PLoKwLGnyZL4BNQA-uZAiaTvzhfiD4Opo_,316050,535667,PDF
+November 2019,2019-11-07,2019-11-09,,,https://www.amphilsoc.org/members/meetings/november-2019,,316052,535668,PDF
+April 2020,2020-04-23,2020-04-25,The April 2020 Meeting of the American Philosophical Society was not held in person. This program as originally planned was canceled due to the COVID-19 pandemic. Members met via web conference only for essential committee and business planning.,,https://www.amphilsoc.org/members/meetings/april-2020,,535669,535670,PDF
+November 2020,2020-11-11,2020-11-13,The November 2020 Meeting of the American Philosophical Society was not held in person. All talks were held via Zoom webinar.,YouTube,https://www.amphilsoc.org/members/meetings/november-2020,https://www.youtube.com/watch?v=49ip-Xa0U58&list=PLoKwLGnyZL4ANb-6o2oasWjr_uDjXRkva,535671,535672,PDF
+April 2021,2021-04-21,2021-04-23,The April 2021 Meeting of the American Philosophical Society was not held in person. All talks were held via Zoom webinar.,,https://www.amphilsoc.org/members/meetings/april-2021,https://www.youtube.com/watch?v=WO8eNDLDDrQ&list=PLoKwLGnyZL4Cc8346Ix89c3oBjg--MwmD,535673,535674,PDF
+November 2021,2021-11-10,2021-11-12,The November 2021 Meeting of the American Philosophical Society was not be held in person. All talks were held via Zoom webinar.,,https://www.amphilsoc.org/members/meetings/november-2021,https://www.youtube.com/watch?v=Xq5Pe9f8o0k&list=PLoKwLGnyZL4AP36Mk9LtavWQQdyVfs9Q-,535675,535676,PDF
+April 2022,2022-04-27,2022-04-29,The April 2022 Meeting of the American Philosophical Society was not held in person. All talks were held via Zoom webinar.,,https://www.amphilsoc.org/members/meetings/april-2022,https://www.youtube.com/watch?v=izfAQ5UwGds&list=PLoKwLGnyZL4AETXKIpRUgrl9BMsgK84nV,535677,535678,PDF
+November 2022,2022-11-17,2022-11-19,,,https://www.amphilsoc.org/members/meetings/november-2022,https://www.youtube.com/watch?v=DTc4NrgUGG0&list=PLoKwLGnyZL4DmJDdA3-CRY76vPQK3YVos,535679,535680,PDF
+April 2023,2023-04-27,2023-04-29,,,https://www.amphilsoc.org/members/meetings/april-2023,https://www.youtube.com/watch?v=WrAabA9U6Ms&list=PLoKwLGnyZL4B9jyLDBLf5ObCiNKDuC4hg,535681,535682,PDF
+November 2023,2023-11-16,2023-11-18,,,https://www.amphilsoc.org/members/meetings/november-2023,https://www.youtube.com/watch?v=43HiO5DdoE4&list=PLoKwLGnyZL4CaJK873wLvAs_nxQZgNOwQ,535683,535684,PDF
+April 2024,2024-04-25,2024-04-27,,,https://www.amphilsoc.org/members/meetings/april-2024,https://www.youtube.com/watch?v=G9lhyqytTjU&list=PLoKwLGnyZL4Cd27HAgZKp1AMQ6uZAg_r4,535685,535686,PDF
+November 2024,2024-11-14,2024-11-16,,YouTube with good summaries,https://www.amphilsoc.org/members/meetings/november-2024,https://www.youtube.com/watch?v=Bw0EiZ3mR6k&list=PLoKwLGnyZL4BkEgjizLy3ocBdqwJBXOP4,535687,535688,PDF
+April 2025,2025-04-23,2025-04-25,,On YouTube but not linked on website program,https://www.amphilsoc.org/members/meetings/april-2025,https://www.youtube.com/watch?v=cSS66v_fVRE&list=PLoKwLGnyZL4DFRpB4l67tZ1AbGNDTldRY,535689,535690,PDF


### PR DESCRIPTION
Updating meetings.csv. This adds nodes for programs from 2011-present (a handful are still missing) and adds a program_viewer column specifying whether they were ingested to Diglib in IIIF or PDF format.